### PR TITLE
chore: renames 1password

### DIFF
--- a/examples/onepassword/main.go
+++ b/examples/onepassword/main.go
@@ -12,15 +12,15 @@ var config = `---
 - name: my_test_credential
   description: Your account
   sources:
-  - type: onepassword
-    onepassword:
+  - type: 1password
+    1password:
       ref: op://{{ $.op_vault }}/my_test_credential/username
 `
 
 var opVault string
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&opVault, "op-vault", "Personal", "The vault for using onepassword CLI")
+	rootCmd.PersistentFlags().StringVar(&opVault, "op-vault", "Personal", "The vault for using 1Password CLI")
 }
 
 var rootCmd = &cobra.Command{

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -19,8 +19,8 @@ var successManifest = `---
   - type: env
     env: 
       key: JIRA_EMAIL
-  - type: onepassword
-    onepassword: 
+  - type: 1password
+    1password: 
       ref: op://{{ $.op_vault }}/jira_email/username
 `
 
@@ -36,6 +36,6 @@ func TestParseManifest(t *testing.T) {
 	require.Equal(t, "Please insert the JIRA account's email", m[0].Sources[0].Config.(*stdin.Config).Prompt)
 	require.Equal(t, "env", m[0].Sources[1].Type)
 	require.Equal(t, "JIRA_EMAIL", m[0].Sources[1].Config.(*env.Config).Key)
-	require.Equal(t, "onepassword", m[0].Sources[2].Type)
+	require.Equal(t, "1password", m[0].Sources[2].Type)
 	require.Equal(t, "op://{{ $.op_vault }}/jira_email/username", m[0].Sources[2].Config.(*onepasswordcli.Config).Ref)
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -25,5 +25,5 @@ func init() {
 	RegisterProvider("bash", bash.Provider)
 	RegisterProvider("env", env.Provider)
 	RegisterProvider("stdin", stdin.Provider)
-	RegisterProvider("onepassword", onepasswordcli.Provider)
+	RegisterProvider("1password", onepasswordcli.Provider)
 }

--- a/status/status.go
+++ b/status/status.go
@@ -8,9 +8,8 @@ import (
 )
 
 type SecretStatus struct {
-	filterIn  pakay.FilterIn
-	secret    secrets.Secret
-	available bool
+	filterIn pakay.FilterIn
+	secret   secrets.Secret
 }
 
 func (ss SecretStatus) Name() string {
@@ -36,8 +35,10 @@ func (ss SecretStatus) Sources() []string {
 	return sources
 }
 
-func (ss SecretStatus) Available() bool {
-	return ss.available
+func (ss SecretStatus) GetValue(ctx context.Context) (string, bool) {
+	return pakay.GetSecretWithOptions(ctx, ss.secret.Name, pakay.SecretOptions{
+		FilterIn: ss.filterIn,
+	})
 }
 
 type CheckOptions struct {
@@ -51,14 +52,10 @@ func CheckSecrets(ctx context.Context) []SecretStatus {
 func CheckSecretsWithOptions(ctx context.Context, opts CheckOptions) []SecretStatus {
 	ss := make([]SecretStatus, 0, len(secrets.All))
 
-	for name, s := range secrets.All {
-		_, ok := pakay.GetSecretWithOptions(ctx, name, pakay.SecretOptions{
-			FilterIn: opts.FilterIn,
-		})
+	for _, s := range secrets.All {
 		ss = append(ss, SecretStatus{
-			filterIn:  opts.FilterIn,
-			secret:    s,
-			available: ok,
+			filterIn: opts.FilterIn,
+			secret:   s,
 		})
 	}
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -1,0 +1,63 @@
+package status
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/jcchavezs/pakay"
+	_ "github.com/jcchavezs/pakay/internal/providers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckSecrets(t *testing.T) {
+	config := `---
+- name: test_secret_1
+  description: This is a test secret
+  sources:
+    - type: env
+      env:
+        key: TEST_ENV_VAR_1
+    - type: env
+      labels: [deprecated]
+      env:
+        key: DEPRECATED_TEST_ENV_VAR_1
+- name: test_secret_2
+  sources:
+  - type: env
+    env:
+      key: TEST_ENV_VAR_2
+`
+
+	err := pakay.LoadSecretsFromBytes([]byte(config))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	ss := CheckSecretsWithOptions(ctx, CheckOptions{
+		FilterIn: func(s pakay.Source) bool {
+			return !slices.Contains(s.Labels, "deprecated")
+		},
+	})
+
+	require.Len(t, ss, 2)
+
+	for _, s := range ss {
+		require.Len(t, ss[0].Sources(), 1)
+		if s.Name() == "test_secret_1" {
+			require.Equal(t, "This is a test secret", s.Description())
+			require.Equal(t, "env: TEST_ENV_VAR_1", s.Sources()[0])
+			t.Setenv("DEPRECATED_TEST_ENV_VAR_1", "A")
+			v, ok := s.GetValue(ctx)
+			require.Equal(t, "", v)
+			require.False(t, ok)
+
+			t.Setenv("TEST_ENV_VAR_1", "A")
+			v, ok = s.GetValue(ctx)
+			require.Equal(t, "A", v)
+			require.True(t, ok)
+		} else {
+			require.Equal(t, "env: TEST_ENV_VAR_2", s.Sources()[0])
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces two primary changes: renaming the "onepassword" provider to "1password" for consistency and clarity, and refactoring the `SecretStatus` functionality to improve how secrets are retrieved and tested. Additionally, a new test suite has been added to validate the updated behavior. Below is a breakdown of the most important changes:

### Provider Renaming:
* Updated all references to the "onepassword" provider to "1password" across multiple files for consistency (`examples/onepassword/main.go`, `internal/parser/parser_test.go`, `internal/providers/providers.go`). [[1]](diffhunk://#diff-b83b1230f0386818a50611252717f962ba0d2d268419972b903e7d938d027b34L15-R23) [[2]](diffhunk://#diff-f8625058bbc944e30e69a0e09139ecd3e0d510f768ecebf132c5182d27f67503L22-R23) [[3]](diffhunk://#diff-f8625058bbc944e30e69a0e09139ecd3e0d510f768ecebf132c5182d27f67503L39-R39) [[4]](diffhunk://#diff-9f74af5c75bdc7e939c7788d82423789cdbd9294ec278476191afe0b95e7b217L28-R28)

### Refactoring `SecretStatus`:
* Removed the `available` field from the `SecretStatus` struct in `status/status.go` and replaced the `Available` method with a new `GetValue` method that retrieves the secret value and its availability dynamically. [[1]](diffhunk://#diff-2b43f8f754e7e61ebc349444f31f588e20353ee7e69b174c7cfbaad101a6d0ebL13) [[2]](diffhunk://#diff-2b43f8f754e7e61ebc349444f31f588e20353ee7e69b174c7cfbaad101a6d0ebL39-R41)
* Simplified the `CheckSecretsWithOptions` function by removing redundant checks and relying on the new `GetValue` method for determining secret availability.

### Testing Enhancements:
* Added a comprehensive test suite in `status/status_test.go` to validate the behavior of the `CheckSecretsWithOptions` and `GetValue` methods. The test ensures secrets are filtered correctly based on labels and validates the retrieval of secret values.