### PR TITLE
fix: delays OP binary check.

### DIFF
--- a/internal/sources/onepassword/cli/cli.go
+++ b/internal/sources/onepassword/cli/cli.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	stdexec "os/exec"
 	"strings"
 
 	"github.com/jcchavezs/pakay/internal/exec"
+	"github.com/jcchavezs/pakay/internal/log"
 	"github.com/jcchavezs/pakay/types"
 )
 
@@ -36,12 +38,13 @@ var Source = types.SecretSource{
 			return nil, errors.New("ref cannot be empty")
 		}
 
-		_, err := exec.Command("command", "-v", "op")
-		if err != nil {
-			return nil, errors.New("1Password CLI not found")
-		}
-
 		return func(ctx context.Context) (string, bool) {
+			_, err := stdexec.LookPath("op")
+			if err != nil {
+				log.Logger.Error("1Password CLI not found", "error", err)
+				return "", false
+			}
+
 			if out, err := exec.CommandContext(ctx, "op", "account", "list"); err != nil {
 				return "", false
 			} else if len(bytes.TrimSpace(out)) == 0 {


### PR DESCRIPTION
This pull request updates the `internal/sources/onepassword/cli/cli.go` file to improve error handling and logging for the 1Password CLI integration. The key changes include replacing the method used to check for the presence of the CLI, adding logging for errors, and restructuring the function for better readability.

### Improvements to error handling and logging:

* **Added logging for missing 1Password CLI**: Introduced the `log.Logger.Error` method to log an error message when the 1Password CLI is not found, providing more visibility into issues. (`[internal/sources/onepassword/cli/cli.goL39-L44](diffhunk://#diff-7bef9cefdb3be8af9b2cce5914880e420cfe0072a1cd6f01a8646c68e7e97308L39-L44)`)

### Code restructuring and simplification:

* **Replaced `exec.Command` with `stdexec.LookPath`**: Changed the method used to verify the presence of the `op` command from `exec.Command` to `stdexec.LookPath`, which is more appropriate for checking the existence of a binary in the system's PATH. (`[internal/sources/onepassword/cli/cli.goL39-L44](diffhunk://#diff-7bef9cefdb3be8af9b2cce5914880e420cfe0072a1cd6f01a8646c68e7e97308L39-L44)`)
* **Refactored import statements**: Added imports for `stdexec` and `log` to support the changes mentioned above. (`[internal/sources/onepassword/cli/cli.goR9-R13](diffhunk://#diff-7bef9cefdb3be8af9b2cce5914880e420cfe0072a1cd6f01a8646c68e7e97308R9-R13)`)