### PR TITLE
chore: adds vulnchecker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
-  
+
+      - name: Install tools
+        run: make install-tools
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run vulncheck
+        run: make vulncheck
+
       - name: Run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ test:
 .PHONY: install-tools
 install-tools: ## Install tools
 	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+	@go install golang.org/x/vuln/cmd/govulncheck@latest
 
 check-tool-%:
 	@which $* > /dev/null || (echo "Install $* with 'make install-tools'"; exit 1 )
@@ -12,3 +13,7 @@ check-tool-%:
 .PHONY: lint
 lint: check-tool-golangci-lint
 	@golangci-lint run ./...
+
+.PHONY: vulncheck
+vulncheck: check-tool-govulncheck
+	@govulncheck ./...


### PR DESCRIPTION
This pull request introduces enhancements to the CI workflow by adding new steps for linting and vulnerability checking, as well as updates to the `Makefile` to support these tools. These changes aim to improve code quality and security.

### CI Workflow Enhancements:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR27-R35): Added steps to install required tools, run linting (`make lint`), and perform vulnerability checks (`make vulncheck`) as part of the CI pipeline.

### `Makefile` Updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R8-R19): Added a new `install-tools` target to install `govulncheck` for vulnerability checks.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R8-R19): Introduced a `vulncheck` target to run `govulncheck` on the codebase.